### PR TITLE
Upgrade clang format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,24 +6,33 @@ jobs:
   check:
     runs-on: ubuntu-22.04
     env:
-      # TODO Bump when newer ubuntu version is available
-      CLANG_VERSION: 15
+      CLANG_VERSION: 17
     steps:
     - uses: actions/checkout@v3
+
     - name: Install clang-format
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
+        CODENAME=$( . /etc/os-release && echo $VERSION_CODENAME )
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+        cat <<EOF | sudo tee /etc/apt/sources.list.d/llvm.list
+        deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CLANG_VERSION} main
+        deb-src [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CLANG_VERSION} main
+        EOF
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends clang-format-${CLANG_VERSION}
+        sudo apt-get install -t llvm-toolchain-${CODENAME}-${CLANG_VERSION} -y --no-install-recommends clang-format-${CLANG_VERSION}
         sudo apt-get clean
+
     - name: Format source files
       run: find include tests -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.ipp' \) -print0 | xargs -0 clang-format-${CLANG_VERSION} -i
+
     - name: Check for differences
       id: assert
       run: |
         set -o pipefail
         git diff --exit-code | tee "clang-format.patch"
+
     - name: Upload patch
       if: failure() && steps.assert.outcome == 'failure'
       uses: actions/upload-artifact@v2
@@ -32,6 +41,7 @@ jobs:
         name: clang-format.patch
         if-no-files-found: ignore
         path: clang-format.patch
+
     - name: What happened?
       if: failure() && steps.assert.outcome == 'failure'
       env:

--- a/include/functional/functor.hpp
+++ b/include/functional/functor.hpp
@@ -18,9 +18,8 @@ template <typename Functor, typename... Args> struct functor final {
 
   friend auto operator|(auto &&v, functor const &self) noexcept -> auto
     requires requires {
-               monadic_apply(std::forward<decltype(v)>(v), functor_type{},
-                             self.args);
-             }
+      monadic_apply(std::forward<decltype(v)>(v), functor_type{}, self.args);
+    }
   {
     return monadic_apply(std::forward<decltype(v)>(v), functor_type{},
                          self.args);
@@ -28,9 +27,9 @@ template <typename Functor, typename... Args> struct functor final {
 
   friend auto operator|(auto &&v, functor &&self) noexcept -> auto
     requires requires {
-               monadic_apply(std::forward<decltype(v)>(v), functor_type{},
-                             std::move(self.args));
-             }
+      monadic_apply(std::forward<decltype(v)>(v), functor_type{},
+                    std::move(self.args));
+    }
   {
     return monadic_apply(std::forward<decltype(v)>(v), functor_type{},
                          std::move(self.args));


### PR DESCRIPTION
It's rather inconvenient to work with clang-17 or gcc-13 , but then reformat with clang-15. Let's keep the versions in sync.