### PR TITLE
Split `inspect_error` from `inspect`

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -15,6 +15,7 @@ set(INCLUDE_SOURCE_FILES
     functional/fail.hpp
     functional/functor.hpp
     functional/fwd.hpp
+    functional/inspect_error.hpp
     functional/inspect.hpp
     functional/or_else.hpp
     functional/recover.hpp

--- a/include/functional/inspect.hpp
+++ b/include/functional/inspect.hpp
@@ -28,57 +28,15 @@ constexpr inline struct inspect_t final {
 } inspect = {};
 
 struct inspect_t::apply final {
-  static auto operator()(some_expected auto &&v, auto &&fn1,
-                         auto &&fn2) noexcept -> decltype(v)
-    requires std::invocable<decltype(fn1), decltype(std::as_const(v.value()))>
-             && std::invocable<decltype(fn2),
-                               decltype(std::as_const(v.error()))>
-             && (!std::is_void_v<decltype(v.value())>)
-  {
-    static_assert(std::is_void_v<std::invoke_result_t<
-                      decltype(fn1), decltype(std::as_const(v.value()))>>);
-    static_assert(std::is_void_v<std::invoke_result_t<
-                      decltype(fn2), decltype(std::as_const(v.error()))>>);
-    if (v.has_value()) {
-      FWD(fn1)(std::as_const(v.value()));
-    } else {
-      FWD(fn2)(std::as_const(v.error()));
-    }
-    return FWD(v);
-  }
-
-  static auto operator()(some_expected auto &&v, auto &&fn1,
-                         auto &&fn2) noexcept -> decltype(v)
-    requires std::invocable<decltype(fn1)>
-             && std::invocable<decltype(fn2),
-                               decltype(std::as_const(v.error()))>
-             && (std::is_void_v<decltype(v.value())>)
-  {
-    static_assert(std::is_void_v<std::invoke_result_t<decltype(fn1)>>);
-    static_assert(std::is_void_v<std::invoke_result_t<
-                      decltype(fn2), decltype(std::as_const(v.error()))>>);
-    if (v.has_value()) {
-      FWD(fn1)();
-    } else {
-      FWD(fn2)(std::as_const(v.error()));
-    }
-    return FWD(v);
-  }
-
   static auto operator()(some_expected auto &&v, auto &&fn) noexcept
       -> decltype(v)
     requires std::invocable<decltype(fn), decltype(std::as_const(v.value()))>
-             && std::invocable<decltype(fn), decltype(std::as_const(v.error()))>
              && (!std::is_void_v<decltype(v.value())>)
   {
     static_assert(std::is_void_v<std::invoke_result_t<
                       decltype(fn), decltype(std::as_const(v.value()))>>);
-    static_assert(std::is_void_v<std::invoke_result_t<
-                      decltype(fn), decltype(std::as_const(v.error()))>>);
     if (v.has_value()) {
       FWD(fn)(std::as_const(v.value()));
-    } else {
-      FWD(fn)(std::as_const(v.error()));
     }
     return FWD(v);
   }
@@ -86,32 +44,11 @@ struct inspect_t::apply final {
   static auto operator()(some_expected auto &&v, auto &&fn) noexcept
       -> decltype(v)
     requires std::invocable<decltype(fn)>
-             && std::invocable<decltype(fn), decltype(std::as_const(v.error()))>
              && (std::is_void_v<decltype(v.value())>)
   {
     static_assert(std::is_void_v<std::invoke_result_t<decltype(fn)>>);
-    static_assert(std::is_void_v<std::invoke_result_t<
-                      decltype(fn), decltype(std::as_const(v.error()))>>);
     if (v.has_value()) {
       FWD(fn)();
-    } else {
-      FWD(fn)(std::as_const(v.error()));
-    }
-    return FWD(v);
-  }
-
-  static auto operator()(some_optional auto &&v, auto &&fn1,
-                         auto &&fn2) noexcept -> decltype(v)
-    requires std::invocable<decltype(fn1), decltype(std::as_const(v.value()))>
-             && std::invocable<decltype(fn2)>
-  {
-    static_assert(std::is_void_v<std::invoke_result_t<
-                      decltype(fn1), decltype(std::as_const(v.value()))>>);
-    static_assert(std::is_void_v<std::invoke_result_t<decltype(fn2)>>);
-    if (v.has_value()) {
-      FWD(fn1)(std::as_const(v.value()));
-    } else {
-      FWD(fn2)();
     }
     return FWD(v);
   }
@@ -119,15 +56,11 @@ struct inspect_t::apply final {
   static auto operator()(some_optional auto &&v, auto &&fn) noexcept
       -> decltype(v)
     requires std::invocable<decltype(fn), decltype(std::as_const(v.value()))>
-             && std::invocable<decltype(fn)>
   {
     static_assert(std::is_void_v<std::invoke_result_t<
                       decltype(fn), decltype(std::as_const(v.value()))>>);
-    static_assert(std::is_void_v<std::invoke_result_t<decltype(fn)>>);
     if (v.has_value()) {
       FWD(fn)(std::as_const(v.value()));
-    } else {
-      FWD(fn)();
     }
     return FWD(v);
   }

--- a/include/functional/inspect_error.hpp
+++ b/include/functional/inspect_error.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#ifndef INCLUDE_FUNCTIONAL_INSPECT_ERROR
+#define INCLUDE_FUNCTIONAL_INSPECT_ERROR
+
+#include "functional/detail/concepts.hpp"
+#include "functional/functor.hpp"
+#include "functional/fwd.hpp"
+#include "functional/utility.hpp"
+
+#include <concepts>
+#include <utility>
+
+namespace fn {
+
+constexpr inline struct inspect_error_t final {
+  auto operator()(auto &&...fn) const noexcept
+      -> functor<inspect_error_t, decltype(fn)...>
+    requires(sizeof...(fn) > 0) && (sizeof...(fn) <= 2)
+  {
+    return {FWD(fn)...};
+  }
+
+  struct apply;
+} inspect_error = {};
+
+struct inspect_error_t::apply final {
+  static auto operator()(some_expected auto &&v, auto &&fn) noexcept
+      -> decltype(v)
+    requires std::invocable<decltype(fn), decltype(std::as_const(v.error()))>
+  {
+    static_assert(std::is_void_v<std::invoke_result_t<
+                      decltype(fn), decltype(std::as_const(v.error()))>>);
+    if (not v.has_value()) {
+      FWD(fn)(std::as_const(v.error()));
+    }
+    return FWD(v);
+  }
+
+  static auto operator()(some_optional auto &&v, auto &&fn) noexcept
+      -> decltype(v)
+    requires std::invocable<decltype(fn)>
+  {
+    static_assert(std::is_void_v<std::invoke_result_t<decltype(fn)>>);
+    if (not v.has_value()) {
+      FWD(fn)();
+    }
+    return FWD(v);
+  }
+};
+
+} // namespace fn
+
+#endif // INCLUDE_FUNCTIONAL_INSPECT_ERROR

--- a/tests/examples/simple.cpp
+++ b/tests/examples/simple.cpp
@@ -7,6 +7,7 @@
 #include "functional/fail.hpp"
 #include "functional/fwd.hpp"
 #include "functional/inspect.hpp"
+#include "functional/inspect_error.hpp"
 #include "functional/or_else.hpp"
 #include "functional/recover.hpp"
 #include "functional/transform.hpp"
@@ -52,8 +53,8 @@ template <typename Fn> struct ImmovableFn final {
 };
 template <typename Fn> ImmovableFn(Fn &&) -> ImmovableFn<Fn>;
 
-TEST_CASE("Demo expected", "[expected][and_then][transform_error][transform]["
-                           "inspect][recover][fail][immovable]")
+TEST_CASE("Demo expected", "[expected][and_then][transform_error][transform]"
+                           "[inspect][inspect_error][recover][fail][immovable]")
 {
   constexpr auto fn1 = [](const char *str, double &peek) {
     using namespace fn;
@@ -86,8 +87,8 @@ TEST_CASE("Demo expected", "[expected][and_then][transform_error][transform]["
                 return std::runtime_error{v.what};
               })
             | transform(fn2)
-            | inspect(
-                [&peek](double d) noexcept -> void { peek = d; },
+            | inspect([&peek](double d) noexcept -> void { peek = d; })
+            | inspect_error(
                 [&peek](std::runtime_error) noexcept -> void { peek = 0; })
             | recover([](auto...) noexcept -> int { return -13; })
             //
@@ -131,8 +132,8 @@ TEST_CASE("Demo optional",
                 }
                 return {std::nullopt};
               })
-            | inspect([&peek](int d) noexcept -> void { peek = d; },
-                      [&peek]() noexcept -> void { peek = 0; })
+            | inspect([&peek](int d) noexcept -> void { peek = d; })
+            | inspect_error([&peek]() noexcept -> void { peek = 0; })
             | or_else([]() noexcept -> std::optional<int> { return -13; })
             | transform([](int i) noexcept -> double { return i + 0.5; })
             //

--- a/tests/tests/CMakeLists.txt
+++ b/tests/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TESTS_SOURCE_FILES
     and_then.cpp
     fail.cpp
     functor.cpp
+    inspect_error.cpp
     inspect.cpp
     or_else.cpp
     recover.cpp

--- a/tests/tests/inspect.cpp
+++ b/tests/tests/inspect.cpp
@@ -21,245 +21,15 @@ struct Error final {
   operator std::string_view() const { return what; }
 };
 
-template <typename... Ts> struct Overload : Ts... {
-  using Ts::operator()...;
-};
-
 } // namespace
 
-TEST_CASE("inspect with two functions", "[inspect][expected][expected_value]")
+TEST_CASE("inspect expected", "[inspect][expected][expected_value]")
 {
   using namespace fn;
 
   using operand_t = std::expected<int, Error>;
   int value = 0;
-  std::string error = {};
   auto fnValue = [&value](auto i) -> void { value = i; };
-  auto fnError = [&error](auto v) -> void { error = v; };
-
-  static_assert(monadic_invocable<inspect_t, operand_t, decltype(fnValue),
-                                  decltype(fnError)>);
-  static_assert([](auto &&fn) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn), decltype(fn)>;
-  }([](auto...) -> void { throw 0; })); // allow generic call
-  static_assert([](auto &&fn1, auto fn2) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](unsigned) -> operand_t { throw 0; },
-    [](std::string_view) {})); // allow conversions
-  static_assert([](auto &&fn1, auto fn2) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn1),
-                             decltype(fn2)>;
-  }([](int) -> operand_t { throw 0; }, [](Error) {})); // allow copy from rvalue
-  static_assert([](auto &&fn1, auto fn2) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn1),
-                             decltype(fn2)>;
-  }([](int const &) -> operand_t { throw 0; },
-    [](Error const &) {})); // allow binding to const lvalue
-
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn1),
-                             decltype(fn2)>;
-  }([](int) -> operand_t { throw 0; }, [](Error &&) {})); // disallow move
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn1),
-                             decltype(fn2)>;
-  }([](int &&) -> operand_t { throw 0; }, [](Error) {})); // disallow move
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](int &) -> operand_t { throw 0; },
-    [](Error) {})); // disallow removing const
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](int) -> operand_t { throw 0; },
-    [](Error &) {})); // disallow removing const
-
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](std::string_view) -> operand_t { throw 0; },
-    [](std::string_view) {})); // wrong type
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; }, [](std::string_view) {})); // wrong arity
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](auto, auto) -> operand_t { throw 0; },
-    [](std::string_view) {})); // wrong arity
-
-  constexpr auto wrong = [](auto) -> void { throw 0; };
-
-  WHEN("operand is lvalue")
-  {
-    WHEN("operand is value")
-    {
-      operand_t a{std::in_place, 12};
-      using T = decltype(a | inspect(fnValue, wrong));
-      static_assert(std::is_same_v<T, operand_t &>);
-      REQUIRE((a | inspect(fnValue, wrong)).value() == 12);
-      CHECK(value == 12);
-    }
-    WHEN("operand is error")
-    {
-      operand_t a{std::unexpect, "Not good"};
-      using T = decltype(a | inspect(wrong, fnError));
-      static_assert(std::is_same_v<T, operand_t &>);
-      REQUIRE((a //
-               | inspect(wrong, fnError))
-                  .error()
-                  .what
-              == "Not good");
-      CHECK(error == "Not good");
-    }
-  }
-
-  WHEN("operand is rvalue")
-  {
-    WHEN("operand is value")
-    {
-      using T
-          = decltype(operand_t{std::in_place, 12} | inspect(fnValue, wrong));
-      static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE((operand_t{std::in_place, 12} | inspect(fnValue, wrong)).value()
-              == 12);
-      CHECK(value == 12);
-    }
-    WHEN("operand is error")
-    {
-      using T = decltype(operand_t{std::unexpect, "Not good"}
-                         | inspect(wrong, fnError));
-      static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE((operand_t{std::unexpect, "Not good"} //
-               | inspect(wrong, fnError))
-                  .error()
-                  .what
-              == "Not good");
-      CHECK(error == "Not good");
-    }
-  }
-}
-
-TEST_CASE("inspect with two functions", "[inspect][expected][expected_void]")
-{
-  using namespace fn;
-
-  using operand_t = std::expected<void, Error>;
-  int count = 0;
-  std::string error = {};
-  auto fnValue = [&count]() -> void { count += 1; };
-  auto fnError = [&error](auto v) -> void { error = v; };
-
-  static_assert(monadic_invocable<inspect_t, operand_t, decltype(fnValue),
-                                  decltype(fnError)>);
-  static_assert([](auto &&fn) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn), decltype(fn)>;
-  }([](auto...) -> void { throw 0; })); // allow generic call
-  static_assert([](auto &&fn1, auto fn2) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; },
-    [](std::string_view) {})); // allow conversions
-  static_assert([](auto &&fn1, auto fn2) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; }, [](Error) {})); // allow copy from rvalue
-  static_assert([](auto &&fn1, auto fn2) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; },
-    [](Error const &) {})); // allow binding to const lvalue
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; }, [](Error &&) {})); // disallow move
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; }, [](Error &) {})); // disallow removing const
-
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; }, [](std::size_t) {})); // wrong type
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](auto) -> operand_t { throw 0; },
-    [](std::string_view) {})); // wrong arity
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](auto, auto) -> operand_t { throw 0; },
-    [](std::string_view) {})); // wrong arity
-
-  constexpr auto wrong = [](auto...) -> void { throw 0; };
-
-  WHEN("operand is lvalue")
-  {
-    WHEN("operand is value")
-    {
-      operand_t a{std::in_place};
-      using T = decltype(a | inspect(fnValue, wrong));
-      static_assert(std::is_same_v<T, operand_t &>);
-      (a | inspect(fnValue, wrong)).value();
-      CHECK(count == 1);
-    }
-    WHEN("operand is error")
-    {
-      operand_t a{std::unexpect, "Not good"};
-      using T = decltype(a | inspect(wrong, fnError));
-      static_assert(std::is_same_v<T, operand_t &>);
-      REQUIRE((a //
-               | inspect(wrong, fnError))
-                  .error()
-                  .what
-              == "Not good");
-      CHECK(error == "Not good");
-    }
-  }
-
-  WHEN("operand is rvalue")
-  {
-    WHEN("operand is value")
-    {
-      using T = decltype(operand_t{std::in_place} | inspect(fnValue, wrong));
-      static_assert(std::is_same_v<T, operand_t &&>);
-      (operand_t{std::in_place} | inspect(fnValue, wrong)).value();
-      CHECK(count == 1);
-    }
-    WHEN("operand is error")
-    {
-      using T = decltype(operand_t{std::unexpect, "Not good"}
-                         | inspect(wrong, fnError));
-      static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE((operand_t{std::unexpect, "Not good"} //
-               | inspect(wrong, fnError))
-                  .error()
-                  .what
-              == "Not good");
-      CHECK(error == "Not good");
-    }
-  }
-}
-
-TEST_CASE("inspect with one function", "[inspect][expected][inspect_generic]")
-{
-  using namespace fn;
-
-  using operand_t = std::expected<int, Error>;
-  int value = 0;
-  std::string error = {};
-  auto fnValue = [&value, &error](auto v) -> void {
-    if constexpr (std::same_as<std::decay_t<decltype(v)>, int>) {
-      value = v;
-    } else {
-      error = v;
-    }
-  };
 
   static_assert(monadic_invocable<inspect_t, operand_t, decltype(fnValue)>);
   static_assert([](auto &&fn) constexpr -> bool {
@@ -267,45 +37,32 @@ TEST_CASE("inspect with one function", "[inspect][expected][inspect_generic]")
   }([](auto...) -> void { throw 0; })); // allow generic call
   static_assert([](auto &&fn) constexpr -> bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](int) -> operand_t { throw 0; },
-             [](std::string_view) {}})); // allow conversions
+  }([](unsigned) -> void {})); // allow conversions
   static_assert([](auto &&fn) constexpr -> bool {
     return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[](int) -> operand_t { throw 0; },
-             [](Error) {}})); // allow copy from rvalue
+  }([](int) -> void {})); // allow copy from rvalue
   static_assert([](auto &&fn) constexpr -> bool {
     return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[](int const &) -> operand_t { throw 0; },
-             [](Error const &) {}})); // allow binding to const lvalue
+  }([](int const &) -> void {})); // allow binding to const lvalue
+
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[](int) -> operand_t { throw 0; },
-             [](Error &&) {}})); // disallow move
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[](int &&) -> operand_t { throw 0; },
-             [](Error) {}})); // disallow move
+  }([](int &&) -> void {})); // disallow move
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](int &) -> operand_t { throw 0; },
-             [](Error) {}})); // disallow removing const
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](int) -> operand_t { throw 0; },
-             [](Error &) {}})); // disallow removing const
+  }([](int &) -> void {})); // disallow removing const
 
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](std::string_view) -> operand_t { throw 0; },
-             [](std::string_view) {}})); // wrong type
+  }([](std::string_view) -> bool { throw 0; })); // wrong type
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](std::string_view) {}})); // wrong arity
+  }([]() -> void {})); // wrong arity
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](auto, auto) -> operand_t { throw 0; },
-             [](std::string_view) {}})); // wrong arity
+  }([](auto, auto) -> void {})); // wrong arity
+
+  constexpr auto wrong = [](auto) -> void { throw 0; };
 
   WHEN("operand is lvalue")
   {
@@ -320,14 +77,13 @@ TEST_CASE("inspect with one function", "[inspect][expected][inspect_generic]")
     WHEN("operand is error")
     {
       operand_t a{std::unexpect, "Not good"};
-      using T = decltype(a | inspect(fnValue));
+      using T = decltype(a | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE((a //
-               | inspect(fnValue))
+               | inspect(wrong))
                   .error()
                   .what
               == "Not good");
-      CHECK(error == "Not good");
     }
   }
 
@@ -342,72 +98,35 @@ TEST_CASE("inspect with one function", "[inspect][expected][inspect_generic]")
     }
     WHEN("operand is error")
     {
-      using T
-          = decltype(operand_t{std::unexpect, "Not good"} | inspect(fnValue));
+      using T = decltype(operand_t{std::unexpect, "Not good"} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
       REQUIRE((operand_t{std::unexpect, "Not good"} //
-               | inspect(fnValue))
+               | inspect(wrong))
                   .error()
                   .what
               == "Not good");
-      CHECK(error == "Not good");
     }
   }
 }
 
-TEST_CASE("inspect with one function",
-          "[inspect][expected][inspect_generic][expected_void]")
+TEST_CASE("inspect void expected", "[inspect][expected][expected_void]")
 {
   using namespace fn;
 
   using operand_t = std::expected<void, Error>;
   int count = 0;
-  std::string error = {};
-  auto fnValue = [&count, &error](auto... v) -> void {
-    if constexpr (sizeof...(v) == 0) {
-      count += 1;
-    } else {
-      error = ("" + ... + v.what);
-    }
-  };
+  auto fnValue = [&count]() -> void { count += 1; };
 
   static_assert(monadic_invocable<inspect_t, operand_t, decltype(fnValue)>);
   static_assert([](auto &&fn) constexpr -> bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
   }([](auto...) -> void { throw 0; })); // allow generic call
-  static_assert([](auto &&fn) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](std::string_view) {}})); // allow conversions
-  static_assert([](auto &&fn) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](Error) {}})); // allow copy from rvalue
-  static_assert([](auto &&fn) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](Error const &) {}})); // allow binding to const lvalue
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](Error &&) {}})); // disallow move
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](Error &) {}})); // disallow removing const
 
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](std::size_t) {}})); // wrong type
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](auto) -> operand_t { throw 0; },
-             [](std::string_view) {}})); // wrong arity
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[]() -> operand_t { throw 0; },
-             [](auto, auto) {}})); // wrong arity
+  }([](auto) -> void {})); // wrong arity
+
+  constexpr auto wrong = [](auto...) -> void { throw 0; };
 
   WHEN("operand is lvalue")
   {
@@ -422,15 +141,13 @@ TEST_CASE("inspect with one function",
     WHEN("operand is error")
     {
       operand_t a{std::unexpect, "Not good"};
-      using T = decltype(a | inspect(fnValue));
+      using T = decltype(a | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
       REQUIRE((a //
-               | inspect(fnValue))
+               | inspect(wrong))
                   .error()
                   .what
               == "Not good");
-      CHECK(error == "Not good");
-      CHECK(count == 0);
     }
   }
 
@@ -445,113 +162,24 @@ TEST_CASE("inspect with one function",
     }
     WHEN("operand is error")
     {
-      using T
-          = decltype(operand_t{std::unexpect, "Not good"} | inspect(fnValue));
+      using T = decltype(operand_t{std::unexpect, "Not good"} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
       REQUIRE((operand_t{std::unexpect, "Not good"} //
-               | inspect(fnValue))
+               | inspect(wrong))
                   .error()
                   .what
               == "Not good");
-      CHECK(error == "Not good");
-      CHECK(count == 0);
     }
   }
 }
 
-TEST_CASE("inspect with two functions", "[inspect][optional]")
+TEST_CASE("inspect optional", "[inspect][optional]")
 {
   using namespace fn;
 
   using operand_t = std::optional<int>;
   int value = 0;
-  int error = 0;
   auto fnValue = [&value](auto i) -> void { value = i; };
-  auto fnError = [&error]() -> void { error += 1; };
-
-  static_assert(monadic_invocable<inspect_t, operand_t, decltype(fnValue),
-                                  decltype(fnError)>);
-  static_assert([](auto &&fn) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn), decltype(fn)>;
-  }([](auto...) -> void { throw 0; })); // allow generic call
-  static_assert([](auto &&fn1, auto fn2) constexpr -> bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](unsigned) -> operand_t { throw 0; }, []() {})); // allow conversions
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](std::string_view) -> operand_t { throw 0; }, []() {})); // wrong type
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([]() -> operand_t { throw 0; }, []() {})); // wrong arity
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](auto) -> operand_t { throw 0; }, [](auto) {})); // wrong arity
-  static_assert(not [](auto &&fn1, auto fn2) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn1),
-                             decltype(fn2)>;
-  }([](int &) -> operand_t { throw 0; }, []() {})); // disallow removing const
-
-  constexpr auto wrong = [](auto...) -> void { throw 0; };
-
-  WHEN("operand is lvalue")
-  {
-    WHEN("operand is value")
-    {
-      operand_t a{12};
-      using T = decltype(a | inspect(fnValue, wrong));
-      static_assert(std::is_same_v<T, operand_t &>);
-      REQUIRE((a | inspect(fnValue, wrong)).value() == 12);
-      CHECK(value == 12);
-    }
-    WHEN("operand is error")
-    {
-      operand_t a{std::nullopt};
-      using T = decltype(a | inspect(wrong, fnError));
-      static_assert(std::is_same_v<T, operand_t &>);
-      REQUIRE(not(a | inspect(wrong, fnError)).has_value());
-      CHECK(error == 1);
-    }
-  }
-
-  WHEN("operand is rvalue")
-  {
-    WHEN("operand is value")
-    {
-      using T = decltype(operand_t{12} | inspect(fnValue, wrong));
-      static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE((operand_t{12} | inspect(fnValue, wrong)).value() == 12);
-      CHECK(value == 12);
-    }
-    WHEN("operand is error")
-    {
-      using T = decltype(operand_t{std::nullopt} | inspect(wrong, fnError));
-      static_assert(std::is_same_v<T, operand_t &&>);
-      REQUIRE(not(operand_t{std::nullopt} //
-                  | inspect(wrong, fnError))
-                     .has_value());
-      CHECK(error == 1);
-    }
-  }
-}
-
-TEST_CASE("inspect with one function", "[inspect][optional][inspect_generic]")
-{
-  using namespace fn;
-
-  using operand_t = std::optional<int>;
-  int value = 0;
-  int error = 0;
-  auto fnValue = [&value, &error](auto... v) -> void {
-    if constexpr ((sizeof...(v)) == 1) {
-      value = (0 + ... + v);
-    } else {
-      error += 1;
-    }
-  };
 
   static_assert(monadic_invocable<inspect_t, operand_t, decltype(fnValue)>);
   static_assert([](auto &&fn) constexpr -> bool {
@@ -559,42 +187,32 @@ TEST_CASE("inspect with one function", "[inspect][optional][inspect_generic]")
   }([](auto...) -> void { throw 0; })); // allow generic call
   static_assert([](auto &&fn) constexpr -> bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](unsigned) -> operand_t { throw 0; },
-             []() {}})); // allow conversions
+  }([](unsigned) -> void {})); // allow conversions
   static_assert([](auto &&fn) constexpr -> bool {
     return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[](int) -> operand_t { throw 0; },
-             []() {}})); // allow copy from rvalue
+  }([](int) -> void {})); // allow copy from rvalue
   static_assert([](auto &&fn) constexpr -> bool {
     return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[](int const &) -> operand_t { throw 0; },
-             []() {}})); // allow binding to const lvalue
+  }([](int const &) -> void {})); // allow binding to const lvalue
+
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t &&, decltype(fn)>;
-  }(Overload{[](int &&) -> operand_t { throw 0; }, []() {}})); // disallow move
+  }([](int &&) -> void {})); // disallow move
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](int &) -> operand_t { throw 0; },
-             []() {}})); // disallow removing const
+  }([](int &) -> void {})); // disallow removing const
 
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](std::string_view) -> operand_t { throw 0; },
-             []() {}})); // wrong type
+  }([](std::string_view) -> void {})); // wrong type
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }([]() -> operand_t { throw 0; })); // wrong arity
+  }([]() -> void {})); // wrong arity
   static_assert(not [](auto &&fn) constexpr->bool {
     return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](auto, auto) -> operand_t { throw 0; },
-             []() {}})); // wrong arity
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }([](auto) -> operand_t { throw 0; })); // wrong arity
-  static_assert(not [](auto &&fn) constexpr->bool {
-    return monadic_invocable<inspect_t, operand_t, decltype(fn)>;
-  }(Overload{[](auto) -> operand_t { throw 0; },
-             [](auto, auto) {}})); // wrong arity
+  }([](auto, auto) -> void {})); // wrong arity
+
+  constexpr auto wrong = [](auto...) -> void { throw 0; };
 
   WHEN("operand is lvalue")
   {
@@ -609,10 +227,9 @@ TEST_CASE("inspect with one function", "[inspect][optional][inspect_generic]")
     WHEN("operand is error")
     {
       operand_t a{std::nullopt};
-      using T = decltype(a | inspect(fnValue));
+      using T = decltype(a | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &>);
-      REQUIRE(not(a | inspect(fnValue)).has_value());
-      CHECK(error == 1);
+      REQUIRE(not(a | inspect(wrong)).has_value());
     }
   }
 
@@ -627,12 +244,11 @@ TEST_CASE("inspect with one function", "[inspect][optional][inspect_generic]")
     }
     WHEN("operand is error")
     {
-      using T = decltype(operand_t{std::nullopt} | inspect(fnValue));
+      using T = decltype(operand_t{std::nullopt} | inspect(wrong));
       static_assert(std::is_same_v<T, operand_t &&>);
       REQUIRE(not(operand_t{std::nullopt} //
-                  | inspect(fnValue))
+                  | inspect(wrong))
                      .has_value());
-      CHECK(error == 1);
     }
   }
 }

--- a/tests/tests/inspect_error.cpp
+++ b/tests/tests/inspect_error.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) 2024 Bronek Kozicki
+//
+// Distributed under the ISC License. See accompanying file LICENSE.md
+// or copy at https://opensource.org/licenses/ISC
+
+#include "functional/inspect_error.hpp"
+#include "functional/functor.hpp"
+
+#include <catch2/catch_all.hpp>
+
+#include <expected>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace {
+struct Error final {
+  std::string what;
+
+  operator std::string_view() const { return what; }
+};
+
+template <typename... Ts> struct Overload : Ts... {
+  using Ts::operator()...;
+};
+
+} // namespace
+
+TEST_CASE("inspect_error expected", "[inspect_error][expected]")
+{
+  using namespace fn;
+
+  using operand_t = std::expected<int, Error>;
+  std::string error = {};
+  auto fnError = [&error](auto v) -> void { error = v; };
+
+  static_assert(
+      monadic_invocable<inspect_error_t, operand_t, decltype(fnError)>);
+  static_assert([](auto &&fn) constexpr -> bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([](auto...) -> void { throw 0; })); // allow generic call
+  static_assert([](auto &&fn) constexpr -> bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([](std::string_view) -> void {})); // allow conversions
+  static_assert([](auto &&fn) constexpr -> bool {
+    return monadic_invocable<inspect_error_t, operand_t &&, decltype(fn)>;
+  }([](Error) -> void {})); // allow copy from rvalue
+  static_assert([](auto &&fn) constexpr -> bool {
+    return monadic_invocable<inspect_error_t, operand_t &&, decltype(fn)>;
+  }([](Error const &) -> void {})); // allow binding to const lvalue
+
+  static_assert(not [](auto &&fn) constexpr->bool {
+    return monadic_invocable<inspect_error_t, operand_t &&, decltype(fn)>;
+  }([](Error &&) -> void {})); // disallow move
+  static_assert(not [](auto &&fn) constexpr->bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([](Error &) -> void {})); // disallow removing const
+
+  static_assert(not [](auto &&fn) constexpr->bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([](std::in_place_t) -> void {})); // wrong type
+  static_assert(not [](auto &&fn) constexpr->bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([]() -> void {})); // wrong arity
+  static_assert(not [](auto &&fn) constexpr->bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([](auto, auto) -> operand_t { throw 0; })); // wrong arity
+
+  constexpr auto wrong = [](auto) -> void { throw 0; };
+
+  WHEN("operand is lvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t a{std::in_place, 12};
+      using T = decltype(a | inspect_error(wrong));
+      static_assert(std::is_same_v<T, operand_t &>);
+      REQUIRE((a | inspect_error(wrong)).value() == 12);
+    }
+    WHEN("operand is error")
+    {
+      operand_t a{std::unexpect, "Not good"};
+      using T = decltype(a | inspect_error(fnError));
+      static_assert(std::is_same_v<T, operand_t &>);
+      REQUIRE((a //
+               | inspect_error(fnError))
+                  .error()
+                  .what
+              == "Not good");
+      CHECK(error == "Not good");
+    }
+  }
+
+  WHEN("operand is rvalue")
+  {
+    WHEN("operand is value")
+    {
+      using T = decltype(operand_t{std::in_place, 12} | inspect_error(wrong));
+      static_assert(std::is_same_v<T, operand_t &&>);
+      REQUIRE((operand_t{std::in_place, 12} | inspect_error(wrong)).value()
+              == 12);
+    }
+    WHEN("operand is error")
+    {
+      using T = decltype(operand_t{std::unexpect, "Not good"}
+                         | inspect_error(fnError));
+      static_assert(std::is_same_v<T, operand_t &&>);
+      REQUIRE((operand_t{std::unexpect, "Not good"} //
+               | inspect_error(fnError))
+                  .error()
+                  .what
+              == "Not good");
+      CHECK(error == "Not good");
+    }
+  }
+}
+
+TEST_CASE("inspect_error optional", "[inspect_error][optional]")
+{
+  using namespace fn;
+
+  using operand_t = std::optional<int>;
+  int error = 0;
+  auto fnError = [&error]() -> void { error += 1; };
+
+  static_assert(
+      monadic_invocable<inspect_error_t, operand_t, decltype(fnError)>);
+  static_assert([](auto &&fn) constexpr -> bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([](auto...) -> void { throw 0; })); // allow generic call
+
+  static_assert(not [](auto &&fn) constexpr->bool {
+    return monadic_invocable<inspect_error_t, operand_t, decltype(fn)>;
+  }([](auto) -> void {})); // wrong arity
+
+  constexpr auto wrong = [](auto...) -> void { throw 0; };
+
+  WHEN("operand is lvalue")
+  {
+    WHEN("operand is value")
+    {
+      operand_t a{12};
+      using T = decltype(a | inspect_error(wrong));
+      static_assert(std::is_same_v<T, operand_t &>);
+      REQUIRE((a | inspect_error(wrong)).value() == 12);
+    }
+    WHEN("operand is error")
+    {
+      operand_t a{std::nullopt};
+      using T = decltype(a | inspect_error(fnError));
+      static_assert(std::is_same_v<T, operand_t &>);
+      REQUIRE(not(a | inspect_error(fnError)).has_value());
+      CHECK(error == 1);
+    }
+  }
+
+  WHEN("operand is rvalue")
+  {
+    WHEN("operand is value")
+    {
+      using T = decltype(operand_t{12} | inspect_error(wrong));
+      static_assert(std::is_same_v<T, operand_t &&>);
+      REQUIRE((operand_t{12} | inspect_error(wrong)).value() == 12);
+    }
+    WHEN("operand is error")
+    {
+      using T = decltype(operand_t{std::nullopt} | inspect_error(fnError));
+      static_assert(std::is_same_v<T, operand_t &&>);
+      REQUIRE(not(operand_t{std::nullopt} //
+                  | inspect_error(fnError))
+                     .has_value());
+      CHECK(error == 1);
+    }
+  }
+}


### PR DESCRIPTION
Instead of single operation doing two things, let's have two different operations, following the same naming convention as  `transform` and `transform_error`