### PR TITLE
Add retry functionality for codecov upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,9 +90,14 @@ jobs:
 
     - name: Upload coverage report
       if: ${{ matrix.configuration == 'Debug' && matrix.compiler == 'gcc' }}
-      uses: codecov/codecov-action@v3
+      uses: wandalen/wretry.action@v1.3.0
       with:
-        files: .build/coverage.xml
-        fail_ci_if_error: true
-        verbose: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+        action: codecov/codecov-action@v3
+        with: |
+          files: .build/coverage.xml 
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+        attempt_limit: 5
+        attempt_delay: 10000
+


### PR DESCRIPTION
This will automatically retry to upload codecov report to codecov.io - hopefully will save us from some headache in the future. Please note that we have seen codecov.io fail even after 5 attempts sometimes.