### PR TITLE
Switch type discriminator to std::in_place_type

### DIFF
--- a/include/functional/expected.hpp
+++ b/include/functional/expected.hpp
@@ -671,7 +671,7 @@ constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
   using error_type = std::remove_cvref_t<Rh>::error_type;
   using type = expected<value_type, error_type>;
   if (lh.has_value() && rh.has_value())
-    return type{std::in_place, pack<lh_type>{FWD(lh).value()}.append(std::type_identity<rh_type>{}, FWD(rh).value())};
+    return type{std::in_place, pack<lh_type>{FWD(lh).value()}.append(std::in_place_type_t<rh_type>{}, FWD(rh).value())};
   else if (not lh.has_value())
     return type{std::unexpect, FWD(lh).error()};
   else
@@ -690,7 +690,7 @@ constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
   using error_type = std::remove_cvref_t<Rh>::error_type;
   using type = expected<value_type, error_type>;
   if (lh.has_value() && rh.has_value())
-    return type{std::in_place, FWD(lh).value().append(std::type_identity<rh_type>{}, FWD(rh).value())};
+    return type{std::in_place, FWD(lh).value().append(std::in_place_type_t<rh_type>{}, FWD(rh).value())};
   else if (not lh.has_value())
     return type{std::unexpect, FWD(lh).error()};
   else

--- a/include/functional/optional.hpp
+++ b/include/functional/optional.hpp
@@ -300,7 +300,7 @@ constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
   using value_type = pack<lh_type, rh_type>;
   using type = optional<value_type>;
   if (lh.has_value() && rh.has_value())
-    return type{std::in_place, pack<lh_type>{FWD(lh).value()}.append(std::type_identity<rh_type>{}, FWD(rh).value())};
+    return type{std::in_place, pack<lh_type>{FWD(lh).value()}.append(std::in_place_type_t<rh_type>{}, FWD(rh).value())};
   else if (not lh.has_value())
     return type{std::nullopt};
   else
@@ -317,7 +317,7 @@ constexpr auto operator&(Lh &&lh, Rh &&rh) noexcept
   using value_type = typename lh_type::template append_type<rh_type>;
   using type = optional<value_type>;
   if (lh.has_value() && rh.has_value())
-    return type{std::in_place, FWD(lh).value().append(std::type_identity<rh_type>{}, FWD(rh).value())};
+    return type{std::in_place, FWD(lh).value().append(std::in_place_type_t<rh_type>{}, FWD(rh).value())};
   else if (not lh.has_value())
     return type{std::nullopt};
   else

--- a/include/functional/utility.hpp
+++ b/include/functional/utility.hpp
@@ -23,15 +23,13 @@ template <typename T> [[nodiscard]] constexpr auto apply_const_lvalue(auto &&v) 
   return static_cast<apply_const_lvalue_t<T, decltype(v)>>(v);
 }
 
-template <typename T> constexpr auto type() noexcept -> std::type_identity<T> { return {}; }
-
 template <typename... Ts> struct pack : detail::pack_base<std::index_sequence_for<Ts...>, Ts...> {
   using _base = detail::pack_base<std::index_sequence_for<Ts...>, Ts...>;
 
   template <typename Arg> using append_type = pack<Ts..., Arg>;
 
   template <typename T>
-  [[nodiscard]] constexpr auto append(std::type_identity<T>, auto &&...args) & noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(std::in_place_type_t<T>, auto &&...args) & noexcept -> append_type<T>
     requires std::is_constructible_v<T, decltype(args)...>
              && requires { static_cast<append_type<T>>(_base::template _append<T>(*this, FWD(args)...)); }
   {
@@ -39,7 +37,7 @@ template <typename... Ts> struct pack : detail::pack_base<std::index_sequence_fo
   }
 
   template <typename T>
-  [[nodiscard]] constexpr auto append(std::type_identity<T>, auto &&...args) const & noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(std::in_place_type_t<T>, auto &&...args) const & noexcept -> append_type<T>
     requires std::is_constructible_v<T, decltype(args)...>
              && requires { static_cast<append_type<T>>(_base::template _append<T>(*this, FWD(args)...)); }
   {
@@ -47,7 +45,7 @@ template <typename... Ts> struct pack : detail::pack_base<std::index_sequence_fo
   }
 
   template <typename T>
-  [[nodiscard]] constexpr auto append(std::type_identity<T>, auto &&...args) && noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(std::in_place_type_t<T>, auto &&...args) && noexcept -> append_type<T>
     requires std::is_constructible_v<T, decltype(args)...>
              && requires { static_cast<append_type<T>>(_base::template _append<T>(std::move(*this), FWD(args)...)); }
   {
@@ -55,7 +53,7 @@ template <typename... Ts> struct pack : detail::pack_base<std::index_sequence_fo
   }
 
   template <typename T>
-  [[nodiscard]] constexpr auto append(std::type_identity<T>, auto &&...args) const && noexcept -> append_type<T>
+  [[nodiscard]] constexpr auto append(std::in_place_type_t<T>, auto &&...args) const && noexcept -> append_type<T>
     requires std::is_constructible_v<T, decltype(args)...>
              && requires { static_cast<append_type<T>>(_base::template _append<T>(std::move(*this), FWD(args)...)); }
   {

--- a/tests/tests/expected.cpp
+++ b/tests/tests/expected.cpp
@@ -21,12 +21,12 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     WHEN("value")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
-          fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")};
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
 
       CHECK(s.and_then( //
                  fn::overload([](int &i, auto &&...) -> fn::expected<bool, Error> { return i == 12; },
                               [](int const &, auto &&...) -> fn::expected<bool, Error> { throw 0; },
-                              [](int &&i, auto &&...) -> fn::expected<bool, Error> { throw 0; },
+                              [](int &&, auto &&...) -> fn::expected<bool, Error> { throw 0; },
                               [](int const &&, auto &&...) -> fn::expected<bool, Error> { return 0; })) //
                 .value());
       CHECK(std::as_const(s)
@@ -37,7 +37,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                                  [](int const &&, auto &&...) -> fn::expected<bool, Error> { throw 0; })) //
                 .value());
       CHECK(fn::expected<fn::pack<int, std::string_view>, Error>{
-          fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")}
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")}
                 .and_then( //
                     fn::overload([](int &, auto &&...) -> fn::expected<bool, Error> { throw 0; },
                                  [](int const &, auto &&...) -> fn::expected<bool, Error> { throw 0; },
@@ -83,7 +83,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     WHEN("value")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
-          fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")};
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
 
       CHECK(s.transform( //
                  fn::overload([](int &i, auto &&...) -> bool { return i == 12; },
@@ -99,7 +99,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                                  [](int const &&, auto &&...) -> bool { throw 0; })) //
                 .value());
       CHECK(fn::expected<fn::pack<int, std::string_view>, Error>{
-          fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")}
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")}
                 .transform( //
                     fn::overload([](int &, auto &&...) -> bool { throw 0; },
                                  [](int const &, auto &&...) -> bool { throw 0; },
@@ -118,7 +118,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
     WHEN("void result")
     {
       fn::expected<fn::pack<int, std::string_view>, Error> s{
-          fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")};
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
 
       CHECK(s.transform( //
                  fn::overload([](int &, auto &&...) -> void {}, [](int const &, auto &&...) -> void { throw 0; },
@@ -132,7 +132,7 @@ TEST_CASE("expected pack support", "[expected][pack][and_then][transform][operat
                                  [](int const &&, auto &&...) -> void { throw 0; })) //
                 .has_value());
       CHECK(fn::expected<fn::pack<int, std::string_view>, Error>{
-          fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")}
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")}
                 .transform( //
                     fn::overload([](int &, auto &&...) -> void { throw 0; },
                                  [](int const &, auto &&...) -> void { throw 0; }, [](int &&, auto &&...) -> void {},

--- a/tests/tests/optional.cpp
+++ b/tests/tests/optional.cpp
@@ -16,12 +16,13 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
   {
     WHEN("value")
     {
-      fn::optional<fn::pack<int, std::string_view>> s{fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")};
+      fn::optional<fn::pack<int, std::string_view>> s{
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
 
       CHECK(s.and_then( //
                  fn::overload([](int &i, auto &&...) -> fn::optional<bool> { return i == 12; },
                               [](int const &, auto &&...) -> fn::optional<bool> { throw 0; },
-                              [](int &&i, auto &&...) -> fn::optional<bool> { throw 0; },
+                              [](int &&, auto &&...) -> fn::optional<bool> { throw 0; },
                               [](int const &&, auto &&...) -> fn::optional<bool> { return 0; })) //
                 .value());
       CHECK(std::as_const(s)
@@ -31,7 +32,8 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                                  [](int &&, auto &&...) -> fn::optional<bool> { throw 0; },
                                  [](int const &&, auto &&...) -> fn::optional<bool> { throw 0; })) //
                 .value());
-      CHECK(fn::optional<fn::pack<int, std::string_view>>{fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")}
+      CHECK(fn::optional<fn::pack<int, std::string_view>>{
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")}
                 .and_then( //
                     fn::overload([](int &, auto &&...) -> fn::optional<bool> { throw 0; },
                                  [](int const &, auto &&...) -> fn::optional<bool> { throw 0; },
@@ -72,7 +74,8 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
   {
     WHEN("value")
     {
-      fn::optional<fn::pack<int, std::string_view>> s{fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")};
+      fn::optional<fn::pack<int, std::string_view>> s{
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")};
 
       CHECK(s.transform( //
                  fn::overload([](int &i, auto &&...) -> bool { return i == 12; },
@@ -87,7 +90,8 @@ TEST_CASE("optional pack support", "[optional][pack][and_then][transform][operat
                                  [](int &&, auto &&...) -> bool { throw 0; },
                                  [](int const &&, auto &&...) -> bool { throw 0; })) //
                 .value());
-      CHECK(fn::optional<fn::pack<int, std::string_view>>{fn::pack<int>{12}.append(fn::type<std::string_view>(), "bar")}
+      CHECK(fn::optional<fn::pack<int, std::string_view>>{
+          fn::pack<int>{12}.append(std::in_place_type<std::string_view>, "bar")}
                 .transform( //
                     fn::overload([](int &, auto &&...) -> bool { throw 0; },
                                  [](int const &, auto &&...) -> bool { throw 0; },

--- a/tests/tests/utility.cpp
+++ b/tests/tests/utility.cpp
@@ -165,32 +165,32 @@ TEST_CASE("append value categories", "[pack][append]")
 
   WHEN("explicit type selection")
   {
-    static_assert(std::same_as<decltype(s.append(fn::type<B>(), 5, 6)), T::append_type<B>>);
+    static_assert(std::same_as<decltype(s.append(std::in_place_type<B>, 5, 6)), T::append_type<B>>);
     static_assert(std::same_as<T::append_type<B>, pack<int, std::string_view, A, B>>);
-    static_assert(decltype(s.append(fn::type<B>(), 5, 6))::size() == 4);
+    static_assert(decltype(s.append(std::in_place_type<B>, 5, 6))::size() == 4);
 
     constexpr C c1{};
-    static_assert(std::same_as<decltype(s.append(fn::type<B const &>(), c1)), T::append_type<B const &>>);
+    static_assert(std::same_as<decltype(s.append(std::in_place_type<B const &>, c1)), T::append_type<B const &>>);
     static_assert(std::same_as<T::append_type<B const &>, pack<int, std::string_view, A, B const &>>);
 
     C c2{};
-    static_assert(std::same_as<decltype(s.append(fn::type<B &>(), c2)), T::append_type<B &>>);
+    static_assert(std::same_as<decltype(s.append(std::in_place_type<B &>, c2)), T::append_type<B &>>);
     static_assert(std::same_as<T::append_type<B &>, pack<int, std::string_view, A, B &>>);
 
     WHEN("constructor takes parameters")
     {
-      CHECK(s.append(fn::type<B>(), 5, 6).invoke(check));
-      CHECK(std::as_const(s).append(fn::type<B>(), 5, 6).invoke(check));
-      CHECK(T{12, "bar", 42}.append(fn::type<B>(), 5, 6).invoke(check));
-      CHECK(std::move(std::as_const(s)).append(fn::type<B>(), 5, 6).invoke(check));
+      CHECK(s.append(std::in_place_type<B>, 5, 6).invoke(check));
+      CHECK(std::as_const(s).append(std::in_place_type<B>, 5, 6).invoke(check));
+      CHECK(T{12, "bar", 42}.append(std::in_place_type<B>, 5, 6).invoke(check));
+      CHECK(std::move(std::as_const(s)).append(std::in_place_type<B>, 5, 6).invoke(check));
     }
 
     WHEN("default constructor")
     {
-      CHECK(s.append(fn::type<C>()).invoke(check));
-      CHECK(std::as_const(s).append(fn::type<C>()).invoke(check));
-      CHECK(T{12, "bar", 42}.append(fn::type<C>()).invoke(check));
-      CHECK(std::move(std::as_const(s)).append(fn::type<C>()).invoke(check));
+      CHECK(s.append(std::in_place_type<C>).invoke(check));
+      CHECK(std::as_const(s).append(std::in_place_type<C>).invoke(check));
+      CHECK(T{12, "bar", 42}.append(std::in_place_type<C>).invoke(check));
+      CHECK(std::move(std::as_const(s)).append(std::in_place_type<C>).invoke(check));
     }
   }
 


### PR DESCRIPTION
This improves consistency with similar uses of `std::in_place_type_t` in C++ standard.